### PR TITLE
correct error version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([lldpad], [1.2.99], [lldp-devel@open-lldp.org])
+AC_INIT([lldpad], [1.1.0], [lldp-devel@open-lldp.org])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 
 m4_pattern_allow([AM_PROG_AR])


### PR DESCRIPTION
When using the lldpad - v command, the version will be displayed incorrectly
![b9e18ba9_9957553](https://github.com/user-attachments/assets/c9de6989-adb5-457f-bb5e-beb2129a55f2)
#5 